### PR TITLE
feat: `mock` no longer returns a disposable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ cmd.mock();
 assert(Deno.Command !== Original);
 ```
 
-Return a disposable:
-
-```typescript
-assert(Symbol.dispose in cmd.mock());
-```
-
 #### `use`
 
 Replace Deno.Command inside the callback:
@@ -142,12 +136,6 @@ import * as fs from "jsr:@chiezo/amber/fs";
 ```
 
 #### `mock`
-
-Return a disposable:
-
-```typescript
-assert(Symbol.dispose in fs.mock());
-```
 
 Replace file system functions as side effects:
 

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -2,13 +2,11 @@ import type { ConstructorSpy } from "@std/testing/mock";
 import * as std from "@std/testing/mock";
 import { tryFinally } from "./internal.ts";
 
-export interface Spy<Command extends string | URL>
-  extends
-    Disposable,
-    ConstructorSpy<
-      Deno.Command,
-      [command: Command, options?: Deno.CommandOptions]
-    > {}
+export interface Spy<Command extends string | URL> extends
+  ConstructorSpy<
+    Deno.Command,
+    [command: Command, options?: Deno.CommandOptions]
+  > {}
 
 export interface Stub<Command extends string | URL> extends Spy<Command> {
   fake: typeof Deno.Command;
@@ -95,11 +93,8 @@ export function dispose() {
   spies.clear();
 }
 
-export function mock(): Disposable {
+export function mock() {
   Deno.Command = CommandProxy;
-  return {
-    [Symbol.dispose]: dispose,
-  };
 }
 
 export function use<T>(fn: () => T): T {

--- a/src/cmd_test.ts
+++ b/src/cmd_test.ts
@@ -14,10 +14,6 @@ describe("mock", () => {
     cmd.mock();
     assert(Deno.Command !== Original);
   });
-
-  it("should return a disposable", () => {
-    assert(Symbol.dispose in cmd.mock());
-  });
 });
 
 describe("use", () => {

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -105,7 +105,7 @@ type FsSpy = {
 };
 
 /** A record of spies for Deno APIs related to file system operations. */
-export interface FileSystemSpy extends Disposable, FsSpy {
+export interface FileSystemSpy extends FsSpy {
 }
 
 /** A record of stubs for Deno APIs related to file system operations. */
@@ -209,10 +209,6 @@ export function stub(
       fs,
       (fn, name) => fake[name] ? std.spy(fake, name) : fn,
     ),
-    [Symbol.dispose]: () => {
-      spies.delete(path);
-      fs.removeSync(temp, { recursive: true });
-    },
   } as FileSystemStub;
 
   spies.set(path, stub);
@@ -225,16 +221,11 @@ export function spy(
   return stub(path, createFs());
 }
 
-export function mock(): Disposable {
+export function mock() {
   if (spies.size === 0) {
     stub(Deno.cwd());
   }
   FsFnNames.forEach((name) => mockFsFn(name));
-  return {
-    [Symbol.dispose]() {
-      dispose();
-    },
-  };
 }
 
 function mockFsFn<T extends FsFnName>(name: T) {

--- a/src/fs_test.ts
+++ b/src/fs_test.ts
@@ -8,10 +8,6 @@ describe("mock", () => {
 
   afterEach(() => fs.dispose());
 
-  it("should return a disposable", () => {
-    assert(Symbol.dispose in fs.mock());
-  });
-
   it("should replace file system functions as side effects", () => {
     fs.mock();
     assert(Deno.readTextFile !== original.readTextFile);

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,7 @@ import { tryFinally } from "./internal.ts";
 
 export interface MockModule {
   dispose(): void;
-  mock(): Disposable;
+  mock(): void;
   restore(): void;
   use<T>(fn: () => T): T;
 }


### PR DESCRIPTION
This enables you to write `beforeEach(() => mock())`